### PR TITLE
Reararnge section_year options by program and year level

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -386,34 +386,30 @@ function App() {
                       onChange={handleInputChange}
                     >
                       <option value="">Select Course/Year/Section</option>
-                      
-                      {/* Fourth Year */}
-                      <option value="BSCS 4">BSCS 4</option>
-                      <option value="BSIS 4">BSIS 4</option>
-
-                      {/* Third Year */}
+                      {/* BSCS */}
+                      <option value="BSCS 1A">BSCS 1A</option>
+                      <option value="BSCS 2A">BSCS 2A</option>
                       <option value="BSCS 3A">BSCS 3A</option>
                       <option value="BSCS 3B">BSCS 3B</option>
+                      <option value="BSCS 4">BSCS 4</option>
+                      {/* BSIS */}
+                      <option value="BSIS 1A">BSIS 1A</option>
+                      <option value="BSIS 2A">BSIS 2A</option>
                       <option value="BSIS 3A">BSIS 3A</option>
                       <option value="BSIS 3B">BSIS 3B</option>
-
-                      {/* Second Year */}
-                      <option value="BSCS 2A">BSCS 2A</option>
-                      <option value="BSIS 2A">BSIS 2A</option>
-                      <option value="BSIT 2A">BSIT 2A</option>
-                      <option value="BSIT 2B">BSIT 2B</option>
-                      <option value="BSIT 2C">BSIT 2C</option>
-                      <option value="BSIT 2D">BSIT 2D</option>
-                      <option value="ACT 2A">ACT 2A</option>
-
-                      {/* First Year */}
-                      <option value="BSCS 1A">BSCS 1A</option>
-                      <option value="BSIS 1A">BSIS 1A</option>
+                      <option value="BSIS 4">BSIS 4</option>
+                      {/* BSIT */}
                       <option value="BSIT 1A">BSIT 1A</option>
                       <option value="BSIT 1B">BSIT 1B</option>
                       <option value="BSIT 1C">BSIT 1C</option>
                       <option value="BSIT 1D">BSIT 1D</option>
+                      <option value="BSIT 2A">BSIT 2A</option>
+                      <option value="BSIT 2B">BSIT 2B</option>
+                      <option value="BSIT 2C">BSIT 2C</option>
+                      <option value="BSIT 2D">BSIT 2D</option>
+                      {/* ACT */}
                       <option value="ACT 1A">ACT 1A</option>
+                      <option value="ACT 2A">ACT 2A</option>
                     </select>
 
                     <div


### PR DESCRIPTION
This update rearranges the section_year dropdown options in the student information form. Instead of listing by year level across programs, the options are now grouped by program (BSCS, BSIS, BSIT, ACT) and ordered by year level starting from first year. This improves usability and makes it easier for users to find their course and year.

**Changes**

- Grouped section/year options by program.
- Ordered each program's options from first year to fourth year.